### PR TITLE
Fixed OxideMod download link

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -12,7 +12,7 @@ echo ":/home/container$ ${MODIFIED_STARTUP}"
 
 if [ -f OXIDE_FLAG ]; then
     echo "Updating OxideMod..."
-    curl -sSL "https://dl.bintray.com/oxidemod/builds/Oxide-Rust.zip" > oxide.zip
+    curl -sSL "https://github.com/OxideMod/Oxide/releases/download/latest/Oxide-Rust.zip" > oxide.zip
     unzip -o -q oxide.zip
     rm oxide.zip
     echo "Done updating OxideMod!"


### PR DESCRIPTION
The bintray link for oxide mod was broken, I've updated it to the official github one that is used on oxidemod.org